### PR TITLE
remove video load for ima setup (caused hls errors)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
- "version": "1.0.0",
+ "version": "2.0.0",
  "name": "@stroeer/stroeer-videoplayer-default-ui",
  "description": "Ströer Videoplayer Default UI",
  "main": "dist/StroeerVideoplayer-default-ui.cjs.js",

--- a/src/UI.ts
+++ b/src/UI.ts
@@ -650,10 +650,6 @@ class UI {
       this.setTimeDisp(timeDisp, videoEl.currentTime, videoEl.duration)
     })
 
-    if (videoEl.paused === true && videoEl.currentTime === 0) {
-      videoEl.load()
-    }
-
     this.onVideoElTimeupdate = () => {
       const percentage = videoEl.currentTime / videoEl.duration * 100
       const percentageString = String(percentage)


### PR DESCRIPTION
For our new Setup with the IMA Sdk and the change of behaviour, that the content video stays in the video element and the ads are played in another adcontainer so that both are completely separated.
Calling the load function seems to break the existing hls stream and an error occurs.