### PR TITLE
get/set volume and muted state from local storage items

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
- "version": "1.0.0",
+ "version": "1.1.0",
  "name": "@stroeer/stroeer-videoplayer-default-ui",
  "description": "Ströer Videoplayer Default UI",
  "main": "dist/StroeerVideoplayer-default-ui.cjs.js",

--- a/src/UI.ts
+++ b/src/UI.ts
@@ -3,6 +3,7 @@ import UIIcons from './sprites/svg/sprite.symbol.svg'
 import noop from './noop'
 import SVGHelper from './SVGHelper'
 import Logger from './Logger'
+import { isTouchDevice, hideElement, showElement, convertLocalStorageIntegerToBoolean, convertLocalStorageStringToNumber } from './utils'
 
 interface IStroeerVideoplayer {
   getUIEl: Function
@@ -31,20 +32,6 @@ declare global {
     mozRequestFullscreen?: () => Promise<void>
     webkitRequestFullscreen?: () => Promise<void>
   }
-}
-
-const isTouchDevice = (): boolean => {
-  return (('ontouchstart' in window) || (navigator.maxTouchPoints > 0) || (navigator.msMaxTouchPoints > 0))
-}
-
-const hideElement = (element: HTMLElement): void => {
-  element.classList.add('hidden')
-  element.setAttribute('aria-hidden', 'true')
-}
-
-const showElement = (element: HTMLElement): void => {
-  element.classList.remove('hidden')
-  element.removeAttribute('aria-hidden')
 }
 
 class UI {
@@ -166,8 +153,13 @@ class UI {
 
   init = (StroeerVideoplayer: IStroeerVideoplayer): void => {
     Logger.log('version', version)
+
     const rootEl = StroeerVideoplayer.getRootEl()
     const videoEl = StroeerVideoplayer.getVideoEl()
+
+    videoEl.muted = convertLocalStorageIntegerToBoolean('StroeerVideoplayerMuted')
+    videoEl.volume = convertLocalStorageStringToNumber('StroeerVideoplayerVolume')
+
     videoEl.removeAttribute('controls')
     const uiEl = StroeerVideoplayer.getUIEl()
     if (uiEl.querySelector('.' + this.uiContainerClassName) !== null) {
@@ -361,6 +353,7 @@ class UI {
             dispatchEvent('UIMute', videoEl.currentTime)
             dispatchEvent('UIDefaultMute', videoEl.currentTime)
             videoEl.muted = true
+            window.localStorage.setItem('StroeerVideoplayerMuted', '1')
           }
         }
       ])
@@ -373,6 +366,7 @@ class UI {
             dispatchEvent('UIUnmute', videoEl.currentTime)
             dispatchEvent('UIDefaultUnmute', videoEl.currentTime)
             videoEl.muted = false
+            window.localStorage.setItem('StroeerVideoplayerMuted', '0')
           }
         }
       ])
@@ -707,6 +701,7 @@ class UI {
       }
       const volume = percentageHeight / 100
       videoEl.volume = volume
+      window.localStorage.setItem('StroeerVideoplayerVolume', volume.toFixed(2))
     }
     const calulateDurationPercentageBasedOnXCoords = (x: number): number => {
       const percentage = (100 / timelineContainer.offsetWidth) * x

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,53 @@
+const isTouchDevice = (): boolean => {
+  return (('ontouchstart' in window) || (navigator.maxTouchPoints > 0) || (navigator.msMaxTouchPoints > 0))
+}
+
+const hideElement = (element: HTMLElement): void => {
+  element.classList.add('hidden')
+  element.setAttribute('aria-hidden', 'true')
+}
+
+const showElement = (element: HTMLElement): void => {
+  element.classList.remove('hidden')
+  element.removeAttribute('aria-hidden')
+}
+
+const convertLocalStorageStringToNumber = (key: string): number => {
+  if (typeof window !== 'undefined') {
+    const localStorageItem = window.localStorage.getItem(key)
+    if (localStorageItem !== null) {
+      const number = parseFloat(localStorageItem)
+      if (number >= 0 && number <= 1) {
+        return number
+      } else {
+        return 0.5
+      }
+    } else {
+      return 0.5
+    }
+  }
+  return 0.5
+}
+
+const convertLocalStorageIntegerToBoolean = (key: string): boolean => {
+  if (typeof window !== 'undefined') {
+    const localStorageItem = window.localStorage.getItem(key)
+    if (localStorageItem !== null) {
+      const probablyInteger = parseInt(localStorageItem, 10)
+      if (isNaN(probablyInteger)) {
+        return false
+      } else {
+        return Boolean(probablyInteger)
+      }
+    }
+  }
+  return false
+}
+
+export {
+  isTouchDevice,
+  hideElement,
+  showElement,
+  convertLocalStorageStringToNumber,
+  convertLocalStorageIntegerToBoolean
+}


### PR DESCRIPTION
The volume and muted state should be exchanged between all UIs. If the user mutes during the advertising, this state should also be kept for the content video and vice versa.
With the IMA SDK we no longer just use the video element to show ads, so we needed another possibility to exchange those states and use the local storage.

For the default UI it can be tested here. It also uses the IVAD UI which does not support it by now.

Sandbox (gast/creative): 
https://esc-1.sb.giga.de/news/optimal-fuers-e-bike-praktische-idee-aus-hoehle-der-loewen-loest-ein-echtes-problem-xyz/ 