### PR TITLE
Increase timeline hover area

### DIFF
--- a/src/UI.scss
+++ b/src/UI.scss
@@ -78,14 +78,21 @@
 				user-select: none;
 			}
 			&:hover {
-				height: 4px;
-				margin-top: -2px;
+				height: 6px;
+				margin-top: -4px;
 				.elapsed-bubble {
 					top: -7px;
 					margin-left: -5px;
 					width: 17px;
 					height: 17px;
 				}
+			}
+			&:before {
+				content: "";
+				position: absolute;
+				top: -10px;
+				height: 18px;
+				width: 100%;
 			}
 			.elapsed-bubble {
 				transition: height ease-in 0.2s, width ease-in 0.2s, top ease-in 0.2s, margin-left ease-in 0.2s;
@@ -97,19 +104,19 @@
 				border-radius: 50%;
 			}
 		}
-                .time {
-	            position: absolute;
-	            left: 96px;
-	            bottom: 4px;
-	            color: #fff;
-	            font-size: 12px;
-		    font-family: Roboto, Arial, Helvetica, sans-serif;
-                    >div {
-	                display: inline-block;
-	                margin: 0 2px;
-                    }
-                }
-                .buttons {
+		.time {
+			position: absolute;
+			left: 96px;
+			bottom: 4px;
+			color: #fff;
+			font-size: 12px;
+			font-family: Roboto, Arial, Helvetica, sans-serif;
+			>div {
+				display: inline-block;
+				margin: 0 2px;
+			}
+		}
+		.buttons {
 			display: block;
 			height: 32px;
 			button {

--- a/src/UI.ts
+++ b/src/UI.ts
@@ -538,15 +538,15 @@ class UI {
         }
       }
 
-      const caluclatedMaxRight = timelineContainer.offsetWidth - seekPreviewContainer.offsetWidth
-      let caluclatedLeft = evt.offsetX - seekPreviewContainer.offsetWidth / 2
-      if (caluclatedLeft < 0) {
-        caluclatedLeft = 0
+      const calculatedMaxRight = timelineContainer.offsetWidth - seekPreviewContainer.offsetWidth
+      let calculatedLeft = evt.offsetX - seekPreviewContainer.offsetWidth / 2
+      if (calculatedLeft < 0) {
+        calculatedLeft = 0
       }
-      if (caluclatedLeft > caluclatedMaxRight) {
-        caluclatedLeft = caluclatedMaxRight
+      if (calculatedLeft > calculatedMaxRight) {
+        calculatedLeft = calculatedMaxRight
       }
-      seekPreviewContainer.style.left = String(caluclatedLeft) + 'px'
+      seekPreviewContainer.style.transform = `translateX(${calculatedLeft}px)`
       const x = evt.offsetX
       const vd = videoEl.duration
       const elWidth = timelineContainer.offsetWidth

--- a/src/_seek-preview.scss
+++ b/src/_seek-preview.scss
@@ -3,7 +3,7 @@
 		position: absolute;
 		height: 96px;
 		width: 114px;
-		top: -104px;
+		top: -114px;
 
 		video {
 			width: 100%;


### PR DESCRIPTION
- Added a `:before` element to the `.timeline` to have a bigger hover area.
- Increased the timeline's hover size by two pixels to be closer to the hover area size. Looks better in my opinion, is this okay?
- Moved the timeline seek container up by `10px` so the hover area does not overlap with the bigger hover area which messed up the `mousemove` event values
- Using `transform: translateX()` instead of `left` on timeline seek container for better performance. Result looks exactly the same for me.