### PR TITLE
do not show spinner when waiting event is thrown

### DIFF
--- a/src/UI.ts
+++ b/src/UI.ts
@@ -290,10 +290,6 @@ class UI {
       showBigPlayButton(modus)
     }
 
-    videoEl.addEventListener('waiting', () => {
-      showLoading(true)
-    })
-
     videoEl.addEventListener('canplay', () => {
       showLoading(false)
     })


### PR DESCRIPTION
When starting the videoplayer, you can shortly see the play button and the loading spinner at the same time. this happened because we showed the spinner when the ima threw a waiting event. but we do not need that because we handle the right behaviour on our own. so I removed that code.

fixes video issue 9: https://github.com/stroeer/video/issues/9

sandbox: https://esc-1.sb.familie.de/kleinkind/gesundheit/grippe-influenza-symptome/