### PR TITLE
do not show overlay play button when loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
- "version": "3.1.0",
+ "version": "3.1.1",
  "name": "@stroeer/stroeer-videoplayer-default-ui",
  "description": "Ströer Videoplayer Default UI",
  "main": "dist/StroeerVideoplayer-default-ui.cjs.js",

--- a/src/UI.ts
+++ b/src/UI.ts
@@ -653,7 +653,9 @@ class UI {
       } else {
         showElement(playButton)
       }
-      showElement(overlayContainer)
+      if (loadingSpinnerContainer.classList.contains('hidden')) {
+        showElement(overlayContainer)
+      }
       hideElement(pauseButton)
     }
     videoEl.addEventListener('pause', this.onVideoElPause)


### PR DESCRIPTION
https://esc-1.sb.familie.de/kleinkind/gesundheit/grippe-influenza-symptome/

When video is paused, the play button overlay is shown. But when the ima sends the waiting event and show loading, we hide the big play button.

Fixes: https://github.com/stroeer/video/issues/9