### PR TITLE
🗑️ Patch default UI to work with new videoplayer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
- "version": "4.0.0",
+ "version": "5.0.0",
  "name": "@stroeer/stroeer-videoplayer-default-ui",
  "description": "Ströer Videoplayer Default UI",
  "main": "dist/StroeerVideoplayer-default-ui.cjs.js",

--- a/src/UI.test.ts
+++ b/src/UI.test.ts
@@ -29,10 +29,7 @@ uiEl.classList.add('stroeer-videoplayer-ui')
 const videoEl = document.createElement('video')
 videoEl.setAttribute('controls', '')
 Object.defineProperty(videoEl, 'duration', { value: 10 })
-const source1 = document.createElement('source')
-source1.type = 'video/mp4'
-source1.src = 'https://evilcdn.net/demo-videos/walialu-44s-testspot-longboarding-240p.mp4'
-videoEl.appendChild(source1)
+videoEl.dataset.src = 'https://evilcdn.net/demo-videos/walialu-44s-testspot-longboarding-240p.mp4'
 rootEl.appendChild(uiEl)
 rootEl.appendChild(videoEl)
 document.body.appendChild(rootEl)

--- a/src/UI.ts
+++ b/src/UI.ts
@@ -516,12 +516,12 @@ class UI {
         hideElement(seekPreviewContainer)
         return
       }
-      const videoSource = videoEl.querySelector('source')
+      const videoSource = videoEl.dataset.src as string
       const HlsJs = StroeerVideoplayer.getHlsJs()
       const canPlayNativeHls = videoEl.canPlayType('application/vnd.apple.mpegurl') === 'probably' || videoEl.canPlayType('application/vnd.apple.mpegurl') === 'maybe'
 
       if (HlsJs.isSupported() === true) {
-        if (this.hls === null || (this.hls !== null && this.hls.url !== videoSource.src)) {
+        if (this.hls === null || (this.hls !== null && this.hls.url !== videoSource)) {
           if (this.hls !== null) {
             this.hls.destroy()
             this.hls = null
@@ -532,7 +532,7 @@ class UI {
             capLevelToPlayerSize: true,
             autoStartLoad: true
           })
-          this.hls.loadSource(videoSource.src)
+          this.hls.loadSource(videoSource)
           this.hls.attachMedia(seekPreviewVideo)
 
           this.hls.on(HlsJs.Events.ERROR, (event: any, data: any) => {
@@ -542,8 +542,8 @@ class UI {
           })
         }
       } else if (canPlayNativeHls) {
-        if (seekPreviewVideo.src !== videoSource.src) {
-          seekPreviewVideo.src = videoSource.src
+        if (seekPreviewVideo.src !== videoSource) {
+          seekPreviewVideo.src = videoSource
         }
       } else {
         console.error('Error trying to create seek preview: No HLS Support found')


### PR DESCRIPTION
New videoplayer has no `<source>` tag anymore;
instead it uses a `data-src`-attribute.

This patches the seek preview to use the `data-src` instead of the `<source>` tag.