### PR TITLE
ENGAGE-4553: fix for errors while dragging timeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
- "version": "5.0.1",
+ "version": "5.0.2",
  "name": "@stroeer/stroeer-videoplayer-default-ui",
  "description": "Ströer Videoplayer Default UI",
  "main": "dist/StroeerVideoplayer-default-ui.cjs.js",
@@ -35,7 +35,7 @@
   "@rollup/plugin-json": "4.1.0",
   "@rollup/plugin-node-resolve": "13.1.3",
   "@rollup/plugin-typescript": "8.3.1",
-  "@stroeer/stroeer-videoplayer": "^2.0.0",
+  "@stroeer/stroeer-videoplayer": "^4.0.0",
   "@superevilmegaco/jest-evil-svg-transformer": "0.0.4",
   "@swc/core": "1.2.50",
   "@swc/wasm": "1.2.50",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "@rollup/plugin-json": "4.1.0",
   "@rollup/plugin-node-resolve": "13.1.3",
   "@rollup/plugin-typescript": "8.3.1",
-  "@stroeer/stroeer-videoplayer": "^4.0.0",
+  "@stroeer/stroeer-videoplayer": "^2.0.0",
   "@superevilmegaco/jest-evil-svg-transformer": "0.0.4",
   "@swc/core": "1.2.50",
   "@swc/wasm": "1.2.50",

--- a/src/UI.ts
+++ b/src/UI.ts
@@ -53,6 +53,7 @@ class UI {
   isMouseDown: Boolean
   hls: any
   hlsErrorOccured: Boolean
+  playPromiseOpen: Boolean
 
   constructor () {
     this.uiContainerClassName = 'default'
@@ -71,6 +72,7 @@ class UI {
     this.isMouseDown = false
     this.hls = null
     this.hlsErrorOccured = false
+    this.playPromiseOpen = false
 
     return this
   }
@@ -316,7 +318,8 @@ class UI {
               dispatchEvent('UIResume', videoEl.currentTime)
               dispatchEvent('UIDefaultResume', videoEl.currentTime)
             }
-            videoEl.play()
+            this.playPromiseOpen = true
+            videoEl.play().then(() => { this.playPromiseOpen = false })
           }
         }
       ])
@@ -332,7 +335,8 @@ class UI {
           callb: () => {
             dispatchEvent('UIReplay', videoEl.duration)
             dispatchEvent('UIDefaultReplay', videoEl.duration)
-            videoEl.play()
+            this.playPromiseOpen = true
+            videoEl.play().then(() => { this.playPromiseOpen = false })
           }
         }
       ])
@@ -344,7 +348,7 @@ class UI {
           callb: () => {
             dispatchEvent('UIPause', videoEl.currentTime)
             dispatchEvent('UIDefaultPause', videoEl.currentTime)
-            videoEl.pause()
+            if (this.playPromiseOpen === false) videoEl.pause()
           }
         }
       ])
@@ -465,7 +469,8 @@ class UI {
         }
         dispatchEvent('UIUIContainerPlay', videoEl.currentTime)
         dispatchEvent('UIDefaultUIContainerPlay', videoEl.currentTime)
-        videoEl.play()
+        this.playPromiseOpen = true
+        videoEl.play().then(() => { this.playPromiseOpen = false })
       } else {
         if (isTouchDevice()) {
           return
@@ -474,7 +479,7 @@ class UI {
         dispatchEvent('UIDefaultPause', videoEl.currentTime)
         dispatchEvent('UIUIContainerPause', videoEl.currentTime)
         dispatchEvent('UIDefaultUIContainerPause', videoEl.currentTime)
-        videoEl.pause()
+        if (this.playPromiseOpen === false) videoEl.pause()
       }
     })
 
@@ -492,13 +497,14 @@ class UI {
         }
         dispatchEvent('UIOverlayContainerPlay', videoEl.currentTime)
         dispatchEvent('UIDefaultOverlayContainerPlay', videoEl.currentTime)
-        videoEl.play()
+        this.playPromiseOpen = true
+        videoEl.play().then(() => { this.playPromiseOpen = false })
       } else {
         dispatchEvent('UIPause', videoEl.currentTime)
         dispatchEvent('UIDefaultPause', videoEl.currentTime)
         dispatchEvent('UIOverlayContainerPause', videoEl.currentTime)
         dispatchEvent('UIDefaultOverlayContainerPause', videoEl.currentTime)
-        videoEl.pause()
+        if (this.playPromiseOpen === false) videoEl.pause()
       }
     })
 
@@ -674,9 +680,10 @@ class UI {
       const percentage = videoEl.currentTime / videoEl.duration * 100
       const bubblePosition = percentage / 100 * timelineContainer.offsetWidth
       this.setTimeDisp(timeDisp, videoEl.currentTime, videoEl.dataset.duration)
-
-      timelineElapsed.style.transform = `scaleX(${percentage}%)`
-      timelineElapsedBubble.style.transform = `translateX(${bubblePosition}px)`
+      if (draggingWhat !== 'timeline') {
+        timelineElapsed.style.transform = `scaleX(${percentage}%)`
+        timelineElapsedBubble.style.transform = `translateX(${bubblePosition}px)`
+      }
     }
     videoEl.addEventListener('timeupdate', this.onVideoElTimeupdate)
 
@@ -771,7 +778,7 @@ class UI {
         case timelineElapsedBubble:
           dispatchEvent('UISeekStart', videoEl.currentTime)
           dispatchEvent('UIDefaultSeekStart', videoEl.currentTime)
-          videoEl.pause()
+          //          if (this.playPromiseOpen === false) videoEl.pause()
           draggingWhat = 'timeline'
           break
         case volumeRange:
@@ -799,7 +806,8 @@ class UI {
         videoEl.currentTime = timelineElapsed.getAttribute('data-timeinseconds')
         dispatchEvent('UISeekEnd', videoEl.currentTime)
         dispatchEvent('UIDefaultSeekEnd', videoEl.currentTime)
-        videoEl.play()
+        this.playPromiseOpen = true
+        videoEl.play().then(() => { this.playPromiseOpen = false })
       }
       if (draggingWhat === 'volume') {
         draggingWhat = ''

--- a/src/UI.ts
+++ b/src/UI.ts
@@ -778,7 +778,6 @@ class UI {
         case timelineElapsedBubble:
           dispatchEvent('UISeekStart', videoEl.currentTime)
           dispatchEvent('UIDefaultSeekStart', videoEl.currentTime)
-          //          if (this.playPromiseOpen === false) videoEl.pause()
           draggingWhat = 'timeline'
           break
         case volumeRange:

--- a/src/UI.ts
+++ b/src/UI.ts
@@ -348,7 +348,7 @@ class UI {
           callb: () => {
             dispatchEvent('UIPause', videoEl.currentTime)
             dispatchEvent('UIDefaultPause', videoEl.currentTime)
-            if (this.playPromiseOpen === false) videoEl.pause()
+            videoEl.pause()
           }
         }
       ])


### PR DESCRIPTION
When dragging timeline, seldomly following error occurs:
`Uncaught (in promise) DOMException: The fetching process for the media resource was aborted by the user agent at the user's request.`
This is a result of pausing while the video is not playing since the play() function is asynchronous.
see https://stackoverflow.com/questions/73959930/uncaught-in-promise-domexception-the-fetching-process-for-the-media-resource
When we drag, the video was paused, so the chance was not bad to run into this error.
youtube does not pause the video while dragging the timeline, it continues to play and jumps to the changed point in time when releasing the mousebutton.

- **In this PR the behaviour has been changed to the youtube style.**
- **Additionally a semaphore has been added to each play() call and a dependency to each pause() call.**