### PR TITLE
ENGAGE-4640: Fix/timeline time as float

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
- "version": "5.0.3",
+ "version": "5.0.4",
  "name": "@stroeer/stroeer-videoplayer-default-ui",
  "description": "Ströer Videoplayer Default UI",
  "main": "dist/StroeerVideoplayer-default-ui.cjs.js",

--- a/src/UI.ts
+++ b/src/UI.ts
@@ -802,9 +802,9 @@ class UI {
       if (draggingWhat === 'timeline') {
         draggingWhat = ''
         updateTimelineWhileDragging(evt)
-        let curtime = timelineElapsed.getAttribute('data-timeinseconds')
-        if (curtime === null) curtime = '0.0'
-        videoEl.currentTime = parseFloat(curtime)
+        let currentTime = timelineElapsed.getAttribute('data-timeinseconds')
+        if (currentTime === null) currentTime = '0.0'
+        videoEl.currentTime = parseFloat(currentTime)
         dispatchEvent('UISeekEnd', videoEl.currentTime)
         dispatchEvent('UIDefaultSeekEnd', videoEl.currentTime)
         this.playPromiseOpen = true

--- a/src/UI.ts
+++ b/src/UI.ts
@@ -802,7 +802,9 @@ class UI {
       if (draggingWhat === 'timeline') {
         draggingWhat = ''
         updateTimelineWhileDragging(evt)
-        videoEl.currentTime = timelineElapsed.getAttribute('data-timeinseconds')
+        let curtime = timelineElapsed.getAttribute('data-timeinseconds')
+        if (curtime === null) curtime = '0.0'
+        videoEl.currentTime = parseFloat(curtime)
         dispatchEvent('UISeekEnd', videoEl.currentTime)
         dispatchEvent('UIDefaultSeekEnd', videoEl.currentTime)
         this.playPromiseOpen = true


### PR DESCRIPTION
The Timeline drag sometimes throws errors on the console, that time is not a float value.
We now ensure that it is a float, if the String value in dataset is not parseFloatable, it is set to 0.0