### PR TITLE
✨ hls.js preview ignoreDevicePixelRatio to true

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
- "version": "5.0.4",
+ "version": "5.1.0",
  "name": "@stroeer/stroeer-videoplayer-default-ui",
  "description": "Ströer Videoplayer Default UI",
  "main": "dist/StroeerVideoplayer-default-ui.cjs.js",

--- a/src/UI.ts
+++ b/src/UI.ts
@@ -536,7 +536,8 @@ class UI {
             maxBufferSize: 0,
             maxBufferLength: 10,
             capLevelToPlayerSize: true,
-            autoStartLoad: true
+            autoStartLoad: true,
+            ignoreDevicePixelRatio: true
           })
           this.hls.loadSource(videoSource)
           this.hls.attachMedia(seekPreviewVideo)


### PR DESCRIPTION
The seek-preview uses a mini video tag for preview (will be changed to images soon).

For this video preview we also use a hls.js instance if supported. We set `ignoreDevicePixelRatio` to `true` for this instance now.

See: https://github.com/video-dev/hls.js/blob/master/docs/API.md#ignoredevicepixelratio